### PR TITLE
feat: 포인트 상위 랭킹 10명의 회원 정보 가져오기 구현

### DIFF
--- a/src/main/java/com/uplus/matdori/category/controller/RankingController.java
+++ b/src/main/java/com/uplus/matdori/category/controller/RankingController.java
@@ -1,13 +1,15 @@
 package com.uplus.matdori.category.controller;
 
-import com.uplus.matdori.category.model.dto.CategoryDTO;
-import com.uplus.matdori.category.model.service.RankingService;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
+import com.uplus.matdori.category.model.dto.UserRankingDTO;
+import com.uplus.matdori.category.model.service.RankingService;
 
 /*
  * @RestController
@@ -36,8 +38,9 @@ public class RankingController {
         this.rankingService = rankingService;
     }
 
-    @GetMapping
-    public List<CategoryDTO> getRankings() {
-        return rankingService.getRankings();
+    @GetMapping("/top10")
+    public ResponseEntity<List<UserRankingDTO>> getTopRankingUsers() {
+        List<UserRankingDTO> topUsers = rankingService.getTopRankingUsers();
+        return ResponseEntity.ok(topUsers);
     }
 }

--- a/src/main/java/com/uplus/matdori/category/model/dao/UserDAO.java
+++ b/src/main/java/com/uplus/matdori/category/model/dao/UserDAO.java
@@ -1,5 +1,7 @@
 package com.uplus.matdori.category.model.dao;
 
+import java.util.List;
+
 import com.uplus.matdori.category.model.dto.UserDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -18,4 +20,7 @@ public interface UserDAO {
 
     // 특정 카테고리 방문 횟수 조회
     int getCategoryVisitCount(@Param("userId") String userId, @Param("columnName") String columnName);
+    
+    // point 상위 10명의 회원 정보 조회
+	List<UserDTO> getTopRankingUsers();
 }

--- a/src/main/java/com/uplus/matdori/category/model/dto/UserDTO.java
+++ b/src/main/java/com/uplus/matdori/category/model/dto/UserDTO.java
@@ -13,13 +13,16 @@ import java.util.Collections;
 @NoArgsConstructor
 @ToString
 public class UserDTO {
-    private String userId;  // 회원 ID (VARCHAR 10)
+    private String user_id;  // 회원 ID (VARCHAR 10)
     private int point;  // 포인트 (INT)
     private String password;  // 비밀번호 (VARCHAR 16)
-    private List<Integer> categoryVisits;  // 카테고리별 방문 횟수 (C_1 ~ C_15)
+    private List<Integer> categoryVisits = new ArrayList<>(Collections.nCopies(15, 0));
 
-    //카테고리별 방문 횟수 조회
-    public List<Integer> getCategoryVisits() { return categoryVisits; }
+    // 카테고리별 방문 횟수 조회
+    public List<Integer> getCategoryVisits() { 
+        return categoryVisits;
+    }
+    
     public void setCategoryVisits(List<Integer> categoryVisits) {
         this.categoryVisits = categoryVisits != null ? categoryVisits : new ArrayList<>(Collections.nCopies(15, 0));
     }

--- a/src/main/java/com/uplus/matdori/category/model/dto/UserRankingDTO.java
+++ b/src/main/java/com/uplus/matdori/category/model/dto/UserRankingDTO.java
@@ -1,0 +1,13 @@
+package com.uplus.matdori.category.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class UserRankingDTO {
+	private String user_id;
+    private int point;
+}

--- a/src/main/java/com/uplus/matdori/category/model/service/RankingService.java
+++ b/src/main/java/com/uplus/matdori/category/model/service/RankingService.java
@@ -1,9 +1,9 @@
 package com.uplus.matdori.category.model.service;
 
-import com.uplus.matdori.category.model.dto.CategoryDTO;
+import com.uplus.matdori.category.model.dto.UserRankingDTO;
 
 import java.util.List;
 
 public interface RankingService {
-    List<CategoryDTO> getRankings();
+    List<UserRankingDTO> getTopRankingUsers();
 }

--- a/src/main/java/com/uplus/matdori/category/model/service/RankingServiceImp.java
+++ b/src/main/java/com/uplus/matdori/category/model/service/RankingServiceImp.java
@@ -1,22 +1,30 @@
 package com.uplus.matdori.category.model.service;
 
-import com.uplus.matdori.category.model.dao.HistoryDAO;
-import com.uplus.matdori.category.model.dto.CategoryDTO;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 
-import java.util.List;
+import com.uplus.matdori.category.model.dao.UserDAO;
+import com.uplus.matdori.category.model.dto.UserDTO;
+import com.uplus.matdori.category.model.dto.UserRankingDTO;
 
 //랭킹 정보 관련 기능들을 포함한 RankingSericeImp
 @Service
 public class RankingServiceImp implements RankingService {
-    private final HistoryDAO historyDAO;
+    private final UserDAO userDAO;
 
-    public RankingServiceImp(HistoryDAO historyDAO) {
-        this.historyDAO = historyDAO;
+    public RankingServiceImp(UserDAO userDAO) {
+        this.userDAO = userDAO;
     }
 
     @Override
-    public List<CategoryDTO> getRankings() {
-        return List.of();
+    public List<UserRankingDTO> getTopRankingUsers() {    	
+        List<UserDTO> users = userDAO.getTopRankingUsers();
+        System.out.println("랭킹 조회 결과: " + users);
+        // UserDTO -> UserRankingDTO 변환 과정
+        return users.stream()
+        		.map(user -> new UserRankingDTO(user.getUser_id(), user.getPoint()))
+        		.collect(Collectors.toList());
     }
 }

--- a/src/main/resources/mapper/user.xml
+++ b/src/main/resources/mapper/user.xml
@@ -39,5 +39,10 @@
     <select id="getCategoryVisitCount" parameterType="map" resultType="int">
         SELECT ${columnName} FROM 회원정보 WHERE user_id = #{userId}
     </select>
+    
+    <!-- 전체 회원 중 많은 point를 갖고 있는 상위 10명의 데이터 조회 -->
+    <select id="getTopRankingUsers" resultType="com.uplus.matdori.category.model.dto.UserDTO">
+    	SELECT user_id, point FROM 회원정보 ORDER BY point DESC LIMIT 10
+    </select>
 
 </mapper>


### PR DESCRIPTION
## 📝변경 사항

> 관련 이슈: #6
- UserDTO에서 일부 필드만 사용하기 때문에 확장성을 위해 UserRankingDTO 구현
- DB에서 UserDTO 형식으로 받아와서 UserRankingDTO로 변환하여 응답 생성

## 🤔리뷰 요구사항 (선택)

- UserDTO에서 존재하는 필드 중에 일부만 사용할 때는 UserRankingDTO처럼 새로 구현하는 것이 더 좋은 방법일까요? 개인적인 의견 부탁 드릴게요!

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/1a3649a6-af6b-4935-8224-f7c3b63eac6f)
- ranking/top10 path로 GET 요청 시 point을 기준으로 상위 10명의 회원ID와 포인트 반환
