### PR TITLE
feat: 특정 회원의 랭킹 조회 구현

### DIFF
--- a/src/main/java/com/uplus/matdori/category/controller/RankingController.java
+++ b/src/main/java/com/uplus/matdori/category/controller/RankingController.java
@@ -46,4 +46,9 @@ public class RankingController {
         List<UserRankingDTO> topUsers = rankingService.getTopRankingUsers();
         return ResponseEntity.ok(ApiResponse.success(topUsers));
     }
+    
+    @GetMapping("/myRanking/{user_id}")
+    public ResponseEntity<ApiResponse<MyRankingDTO>> getMyRanking(@PathVariable String user_id) {
+    	return rankingService.getMyRanking(user_id);
+    }
 }

--- a/src/main/java/com/uplus/matdori/category/model/dao/UserDAO.java
+++ b/src/main/java/com/uplus/matdori/category/model/dao/UserDAO.java
@@ -2,9 +2,11 @@ package com.uplus.matdori.category.model.dao;
 
 import java.util.List;
 
-import com.uplus.matdori.category.model.dto.UserDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+
+import com.uplus.matdori.category.model.dto.MyRankingDTO;
+import com.uplus.matdori.category.model.dto.UserDTO;
 
 @Mapper
 public interface UserDAO {
@@ -23,4 +25,7 @@ public interface UserDAO {
     
     // point 상위 10명의 회원 정보 조회
 	List<UserDTO> getTopRankingUsers();
+
+	// 나의 랭킹 조회
+	MyRankingDTO getMyRanking(@Param("user_id") String user_id);
 }

--- a/src/main/java/com/uplus/matdori/category/model/dto/MyRankingDTO.java
+++ b/src/main/java/com/uplus/matdori/category/model/dto/MyRankingDTO.java
@@ -1,0 +1,13 @@
+package com.uplus.matdori.category.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class MyRankingDTO {
+	private String user_id;
+	private int ranking;
+}

--- a/src/main/java/com/uplus/matdori/category/model/service/RankingService.java
+++ b/src/main/java/com/uplus/matdori/category/model/service/RankingService.java
@@ -1,9 +1,14 @@
 package com.uplus.matdori.category.model.service;
 
 import com.uplus.matdori.category.model.dto.UserRankingDTO;
+import com.uplus.matdori.category.model.dto.ApiResponse;
+import com.uplus.matdori.category.model.dto.MyRankingDTO;
 
 import java.util.List;
 
+import org.springframework.http.ResponseEntity;
+
 public interface RankingService {
     List<UserRankingDTO> getTopRankingUsers();
+    ResponseEntity<ApiResponse<MyRankingDTO>> getMyRanking(String user_id);
 }

--- a/src/main/java/com/uplus/matdori/category/model/service/RankingServiceImp.java
+++ b/src/main/java/com/uplus/matdori/category/model/service/RankingServiceImp.java
@@ -3,9 +3,13 @@ package com.uplus.matdori.category.model.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import com.uplus.matdori.category.model.dao.UserDAO;
+import com.uplus.matdori.category.model.dto.ApiResponse;
+import com.uplus.matdori.category.model.dto.MyRankingDTO;
 import com.uplus.matdori.category.model.dto.UserDTO;
 import com.uplus.matdori.category.model.dto.UserRankingDTO;
 
@@ -27,4 +31,19 @@ public class RankingServiceImp implements RankingService {
         		.map(user -> new UserRankingDTO(user.getUser_id(), user.getPoint()))
         		.collect(Collectors.toList());
     }
+
+	@Override
+	public ResponseEntity<ApiResponse<MyRankingDTO>> getMyRanking(String user_id) {
+		try {
+			MyRankingDTO myRanking = userDAO.getMyRanking(user_id);
+			// 존재하지 않는 회원의 랭킹을 조회한 경우
+			if(myRanking == null) {
+				return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error("존재하지 않는 회원입니다."));
+			}
+			// 존재하는 회원의 랭킹을 조회한 경우
+			return ResponseEntity.ok(ApiResponse.success(myRanking));
+		}catch(Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
 }

--- a/src/main/resources/mapper/user.xml
+++ b/src/main/resources/mapper/user.xml
@@ -40,5 +40,10 @@
     <select id="getTopRankingUsers" resultType="com.uplus.matdori.category.model.dto.UserDTO">
     	SELECT user_id, point FROM 회원정보 ORDER BY point DESC LIMIT 10
     </select>
+    
+    <!-- 특정 회원의 point 랭킹 조회 -->
+    <select id="getMyRanking" parameterType="java.lang.String" resultType="com.uplus.matdori.category.model.dto.MyRankingDTO">
+    	SELECT user_id, ranking FROM (SELECT user_id, point, RANK() OVER (ORDER BY point DESC) AS ranking FROM 회원정보) AS sortRank WHERE user_id = #{user_id};
+    </select>
 
 </mapper>


### PR DESCRIPTION
## 📝변경 사항

- UserDTO에서 일부 필드만 사용하기 때문에 확장성을 위해 MyRankingDTO 구현
- DB에서 조회 후 받아온 MyRankingDTO 객체를 ResponseEntity로 감싸서 400, 500 에러 처리

## 🤔리뷰 요구사항 (선택)

- 특정 회원 랭킹 조회 시 user_id와 랭킹을 반환하는데, user_id가 필요할지 갑자기 의문이 드네요..

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/f8a96cdf-1d4a-42f8-8d4b-952e952522f2)
- 존재하는 회원의 랭킹 조회할 경우
---
![image](https://github.com/user-attachments/assets/e966cbc3-e8e3-4668-9ea7-2548cd49e526)
- 존재하지 않는 회원의 랭킹 조회할 경우
---
![image](https://github.com/user-attachments/assets/77acee3d-80fd-4a3f-884b-5b9065c9eb8d)
- 회원 정보가 파라미터에 없을 경우