### PR TITLE
사용자 선호 카테고리 기반 뽑기 구현

### DIFF
--- a/src/main/java/com/uplus/matdori/category/controller/SelectController.java
+++ b/src/main/java/com/uplus/matdori/category/controller/SelectController.java
@@ -70,4 +70,10 @@ public class SelectController {
     public ResponseEntity<ApiResponse<NaverLocalResponseDTO>> getRandomCategory(@RequestParam double latitude, @RequestParam double longitude, @PathVariable Optional<String> selectCategoryName) {
         return selectService.getRandomCategory(latitude, longitude, selectCategoryName.orElse(null));
     }
+    
+    @GetMapping("/prefer/{userId}")
+    public ResponseEntity<ApiResponse<NaverLocalResponseDTO>> getPreferCategory(@RequestParam double latitude, @RequestParam double longitude, @PathVariable String userId) {
+        String categoryName = selectService.getPreferredCategory(userId);
+    	return selectService.getRandomCategory(latitude, longitude, categoryName);
+    }
 }

--- a/src/main/java/com/uplus/matdori/category/model/service/SelectServiceImp.java
+++ b/src/main/java/com/uplus/matdori/category/model/service/SelectServiceImp.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -96,14 +97,26 @@ public class SelectServiceImp implements SelectService {
         UserDTO user = userDAO.getUserById(userId);
         List<Integer> categoryVisits = user.getCategoryVisits(); // List<Integer>로 변경
 
-        int maxVisits = 0, bestCategory = 1;
-        for (int i = 0; i < categoryVisits.size(); i++) { // .length → .size() 사용
-            if (categoryVisits.get(i) > maxVisits) { // 배열 인덱싱 → get(i) 사용
+        int maxVisits = 0;
+        List<Integer> bestCategories = new ArrayList<>();
+
+        // 가장 많이 방문한 카테고리 찾기
+        for (int i = 0; i < categoryVisits.size(); i++) {
+            if (categoryVisits.get(i) > maxVisits) {
                 maxVisits = categoryVisits.get(i);
-                bestCategory = i + 1;
+                bestCategories.clear(); // 새로운 최댓값이 나오면 리스트 초기화
+                bestCategories.add(i + 1); // 카테고리 번호는 1부터 시작
+            } else if (categoryVisits.get(i) == maxVisits) {
+                bestCategories.add(i + 1); // 동일한 최댓값이면 리스트에 추가
             }
         }
-        return categoryDAO.search(bestCategory);
+
+        // 랜덤으로 하나 선택
+        Random random = new Random();
+        int randomIndex = random.nextInt(bestCategories.size());
+        int selectedCategory = bestCategories.get(randomIndex);
+
+        return categoryDAO.search(selectedCategory);
     }
 
     public String getRegionName(double latitude, double longitude) {


### PR DESCRIPTION
## 📝변경 사항

- 사용자 선호 카테고리 기반 뽑기 구현
- 사용자 선호 카테고리 중복 시 랜덤 선택 구현

## 🤔리뷰 요구사항

- 기존에는 사용자 선호 카테고리를 찾을 때, 방문 횟수가 동일한 경우 인덱스가 앞쪽인 카테고리를 선택했으나, 이제는 동일한 방문 횟수를 가진 카테고리 중에서 무작위로 하나를 선택하도록 수정하였습니다.

## 스크린샷
현재 test 계정은 한식, 양식, 중식 3가지 카테고리를 가장 선호하고 있습니다.
![image](https://github.com/user-attachments/assets/ab9f856a-957e-4010-8b9e-a6e7ca327c85)
<br/>
![image](https://github.com/user-attachments/assets/976daf14-ab61-424e-a31a-789df52c3adc)
<br/>
![image](https://github.com/user-attachments/assets/4f88d66a-5154-4efd-a13a-a197bbdcad47)
