### PR TITLE
feat: history_id 기반으로 특정 히스토리의 평점 업데이트하는 기능 추가

### DIFF
--- a/src/main/java/com/uplus/matdori/category/controller/HistoryController.java
+++ b/src/main/java/com/uplus/matdori/category/controller/HistoryController.java
@@ -1,17 +1,22 @@
 package com.uplus.matdori.category.controller;
 
+import com.uplus.matdori.category.model.dto.ApiResponse;
 import com.uplus.matdori.category.model.dto.HistoryDTO;
 import com.uplus.matdori.category.model.service.HistoryService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 /*
  * @RestController
  *   RestFul Service를 위한 Conrtoller
  *   모든 메서드의 응답을  @ResponseBody를 붙여주는 효과
  */
+@Slf4j
 @RestController
 
 //RestFul에서 서비스할 자원(Domain)명을 붙인다
@@ -38,10 +43,10 @@ public class HistoryController {
         return historyService.getUserHistory(userId);
     }
 
+    //특정 id를 받아서
     @PostMapping("/rate")
-    public ResponseEntity<String> rateHistory(@RequestBody HistoryDTO historyDTO) {
-        historyService.rateHistory(historyDTO);
-        return ResponseEntity.ok("Rating Submitted Successfully");
+    public ResponseEntity<ApiResponse<Object>> updateRate(@RequestParam int history_id, @RequestParam int rate) {
+        return historyService.rateHistory(history_id, rate); //성공했을 경우
     }
 
     @DeleteMapping("/delete/{historyId}")

--- a/src/main/java/com/uplus/matdori/category/model/dao/HistoryDAO.java
+++ b/src/main/java/com/uplus/matdori/category/model/dao/HistoryDAO.java
@@ -10,4 +10,10 @@ public interface HistoryDAO {
 
     //방문한 식당 정보를 기록
     void insertVisitHistory(HistoryDTO visitHistory);
+
+    //특정 방문 기록을 history_id로 조회
+    HistoryDTO findById(int history_id);
+
+    //특정 방문 기록의 평점(rate) 업데이트
+    void updateRating(HistoryDTO visitHistory);
 }

--- a/src/main/java/com/uplus/matdori/category/model/dto/HistoryDTO.java
+++ b/src/main/java/com/uplus/matdori/category/model/dto/HistoryDTO.java
@@ -11,6 +11,7 @@ import lombok.experimental.Accessors;
 @AllArgsConstructor
 //히스토리 관련 DTO
 public class HistoryDTO {
+    private int history_id; // 방문 내역의 고유 ID (INT, PK)
     private String user_id2; // 회원 ID (VARCHAR 10 / JSON의 "user_id" 값 매핑)
     private int category_id2; // 카테고리 ID (INT / JSON의 "category_id" 값 매핑)
     private String title; // 식당명

--- a/src/main/java/com/uplus/matdori/category/model/service/HistoryService.java
+++ b/src/main/java/com/uplus/matdori/category/model/service/HistoryService.java
@@ -1,11 +1,13 @@
 package com.uplus.matdori.category.model.service;
 
+import com.uplus.matdori.category.model.dto.ApiResponse;
 import com.uplus.matdori.category.model.dto.HistoryDTO;
+import org.springframework.http.ResponseEntity;
 
 import java.util.List;
 
 public interface HistoryService {
     List<HistoryDTO> getUserHistory(String userId);
-    void rateHistory(HistoryDTO historyDTO);
+    ResponseEntity<ApiResponse<Object>> rateHistory(int history_id, int rate);
     void deleteHistory(int historyId);
 }

--- a/src/main/java/com/uplus/matdori/category/model/service/HistoryServiceImp.java
+++ b/src/main/java/com/uplus/matdori/category/model/service/HistoryServiceImp.java
@@ -1,12 +1,21 @@
 package com.uplus.matdori.category.model.service;
 
 import com.uplus.matdori.category.model.dao.HistoryDAO;
+import com.uplus.matdori.category.model.dto.ApiResponse;
 import com.uplus.matdori.category.model.dto.HistoryDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+
+import static java.rmi.server.LogStream.log;
 
 //History 관련 정보들을 처리하는 기능을 가진 HistoryServiceImp
+@Slf4j
 @Service
 public class HistoryServiceImp implements HistoryService {
     private final HistoryDAO historyDAO;
@@ -20,13 +29,34 @@ public class HistoryServiceImp implements HistoryService {
         return List.of();
     }
 
+    //특정 방문 내역의 평점(rate)을 업데이트하는 메소드
     @Override
-    public void rateHistory(HistoryDTO historyDTO) {
+    @Transactional // 데이터 일관성을 위해 트랜잭션 적용
+    public ResponseEntity<ApiResponse<Object>> rateHistory(int history_id, int rate) {
+        // history_id가 유효한지 조회
+        HistoryDTO history = historyDAO.findById(history_id);
 
+        if (history == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error("유효하지 않은 history_id 값이에요!"));
+        }
+
+        log.info(history.toString());
+
+        // rate 값이 0~5 범위를 벗어나면 예외 발생
+        if (rate < 0 || rate > 5) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error("평점은 0~5사이어야 하잖아 이자쉭아"));
+        }
+
+        // 기존 데이터의 rate를 업데이트
+        history.setRate(rate);
+        historyDAO.updateRating(history); // DB에 반영
+
+        //success일 경우에는 Map.of() 넘겨서.. content는 빈 객체를 넘김
+        return ResponseEntity.ok(ApiResponse.success(Map.of()));
     }
 
     @Override
     public void deleteHistory(int historyId) {
-
+        //아직 구현 안해놓음
     }
 }

--- a/src/main/resources/mapper/history.xml
+++ b/src/main/resources/mapper/history.xml
@@ -15,16 +15,21 @@
         VALUES (#{user_id2}, 0, #{url}, #{title}, #{roadAddress}, #{category_id2})
     </insert>
 
+    <!-- id를 통해서 해당하는 히스토리의 모든 정보 읽어오기 -->
+    <select id="findById" parameterType="int" resultType="com.uplus.matdori.category.model.dto.HistoryDTO">
+        SELECT * FROM 방문한_식당_히스토리 WHERE history_id = #{history_id}
+    </select>
+
     <!-- 평점 업데이트 -->
     <update id="updateRating" parameterType="com.uplus.matdori.category.model.dto.HistoryDTO">
         UPDATE 방문한_식당_히스토리
         SET rate = #{rate}
-        WHERE history_id = #{historyId}
+        WHERE history_id = #{history_id}
     </update>
 
     <!-- 히스토리 삭제 -->
     <delete id="deleteHistory" parameterType="java.lang.Integer">
-        DELETE FROM 방문한_식당_히스토리 WHERE history_id = #{historyId}
+        DELETE FROM 방문한_식당_히스토리 WHERE history_id = #{history_id}
     </delete>
 
 </mapper>


### PR DESCRIPTION
## 📝변경 사항
- 특정 방문 내역의 평점(rate)을 업데이트하는 메소드 rateHistory() 구현
- 해당 메소드 구현을 위해 HistoryDAO, HistoryDTO, 그리고 MyBatis와 연결된 history.xml 수정

## 🤔리뷰 요구사항
제가 건드린 부분 (HistoryServiceImp, HistoryService, HistoryDAO, HistoryDTO) 중 여러분이 구현하신 부분에서와 충돌이 발생할 수 있는 부분에 유의해 주세요.

## 스크린샷
<img width="1706" alt="스크린샷 2025-03-20 17 02 59" src="https://github.com/user-attachments/assets/89ef6537-f4ae-4afd-b472-59e11b0e0e2f" />
정상적으로 해당하는 history_id에 대한 히스토리의 평점(rate)가 업로드 되는 것을 확인 가능합니다.