### PR TITLE
feat: 특정 회원의 히스토리 리스트 불러오기 구현

### DIFF
--- a/src/main/java/com/uplus/matdori/category/controller/HistoryController.java
+++ b/src/main/java/com/uplus/matdori/category/controller/HistoryController.java
@@ -1,5 +1,6 @@
 package com.uplus.matdori.category.controller;
 
+import com.uplus.matdori.category.model.dto.ApiResponse;
 import com.uplus.matdori.category.model.dto.HistoryDTO;
 import com.uplus.matdori.category.model.service.HistoryService;
 import org.springframework.http.ResponseEntity;
@@ -33,9 +34,9 @@ public class HistoryController {
         this.historyService = historyService;
     }
 
-    @GetMapping("/getTable/{userId}")
-    public List<HistoryDTO> getUserHistory(@PathVariable String userId) {
-        return historyService.getUserHistory(userId);
+    @GetMapping("/{user_id}") 
+    public ResponseEntity<ApiResponse<List<HistoryDTO>>> getUserHistory(@PathVariable("user_id") String user_id) {
+        return historyService.getUserHistory(user_id);
     }
 
     @PostMapping("/rate")

--- a/src/main/java/com/uplus/matdori/category/model/dao/HistoryDAO.java
+++ b/src/main/java/com/uplus/matdori/category/model/dao/HistoryDAO.java
@@ -7,7 +7,9 @@ import java.util.List;
 
 @Mapper
 public interface HistoryDAO {
-
-    //방문한 식당 정보를 기록
+	// 특정 회원의 히스토리 리스트 조회
+	List<HistoryDTO> getUserHistory(@Param("user_id") String user_id);
+    
+	//방문한 식당 정보를 기록
     void insertVisitHistory(HistoryDTO visitHistory);
 }

--- a/src/main/java/com/uplus/matdori/category/model/dto/HistoryDTO.java
+++ b/src/main/java/com/uplus/matdori/category/model/dto/HistoryDTO.java
@@ -11,10 +11,11 @@ import lombok.experimental.Accessors;
 @AllArgsConstructor
 //히스토리 관련 DTO
 public class HistoryDTO {
+	private int history_id; // 히스토리 ID (INT / AUTO_INCREMENT)
     private String user_id2; // 회원 ID (VARCHAR 10 / JSON의 "user_id" 값 매핑)
-    private int category_id2; // 카테고리 ID (INT / JSON의 "category_id" 값 매핑)
-    private String title; // 식당명
-    private String roadAddress; // 도로명 주소
-    private String url; // 식당 URL (TEXT)
     private int rate = 0; // 평점 (INT / 기본값 0 설정)
+    private String url; // 식당 URL (TEXT)
+    private String title; // 식당명 (VARCHAR(255))
+    private String roadAddress; // 주소 (VARCHAR(255))
+    private int category_id2; // 카테고리 ID (INT / JSON의 "category_id" 값 매핑)
 }

--- a/src/main/java/com/uplus/matdori/category/model/service/HistoryService.java
+++ b/src/main/java/com/uplus/matdori/category/model/service/HistoryService.java
@@ -1,11 +1,14 @@
 package com.uplus.matdori.category.model.service;
 
-import com.uplus.matdori.category.model.dto.HistoryDTO;
-
 import java.util.List;
 
+import org.springframework.http.ResponseEntity;
+
+import com.uplus.matdori.category.model.dto.ApiResponse;
+import com.uplus.matdori.category.model.dto.HistoryDTO;
+
 public interface HistoryService {
-    List<HistoryDTO> getUserHistory(String userId);
+	ResponseEntity<ApiResponse<List<HistoryDTO>>> getUserHistory(String user_id);
     void rateHistory(HistoryDTO historyDTO);
     void deleteHistory(int historyId);
 }

--- a/src/main/java/com/uplus/matdori/category/model/service/HistoryServiceImp.java
+++ b/src/main/java/com/uplus/matdori/category/model/service/HistoryServiceImp.java
@@ -1,23 +1,53 @@
 package com.uplus.matdori.category.model.service;
 
-import com.uplus.matdori.category.model.dao.HistoryDAO;
-import com.uplus.matdori.category.model.dto.HistoryDTO;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
+import com.uplus.matdori.category.model.dao.HistoryDAO;
+import com.uplus.matdori.category.model.dao.UserDAO;
+import com.uplus.matdori.category.model.dto.ApiResponse;
+import com.uplus.matdori.category.model.dto.HistoryDTO;
+import com.uplus.matdori.category.model.dto.UserDTO;
 
 //History 관련 정보들을 처리하는 기능을 가진 HistoryServiceImp
 @Service
 public class HistoryServiceImp implements HistoryService {
     private final HistoryDAO historyDAO;
-
-    public HistoryServiceImp(HistoryDAO historyDAO) {
+    private final UserDAO userDAO;
+    
+    public HistoryServiceImp(HistoryDAO historyDAO, UserDAO userDAO) {
         this.historyDAO = historyDAO;
+        this.userDAO = userDAO;
     }
 
     @Override
-    public List<HistoryDTO> getUserHistory(String userId) {
-        return List.of();
+    public ResponseEntity<ApiResponse<List<HistoryDTO>>> getUserHistory(String user_id) {
+    	try {
+    		UserDTO user = userDAO.getUserById(user_id);
+    		
+    		// 존재하지 않는 회원인 경우
+    		if(user == null) {
+    			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.error("존재하지 않는 사용자입니다."));
+    		}
+    		
+    		List<HistoryDTO> historyList = historyDAO.getUserHistory(user_id);
+    		
+    		// 존재하는 회원의 히스토리가 없는 경우
+			if(historyList == null) {
+				List<HistoryDTO> emptyList = new ArrayList<>();
+				return ResponseEntity.ok(ApiResponse.success(emptyList));
+			}
+			
+			// 존재하는 회원의 히스토리가 존재하는 경우
+			return ResponseEntity.ok(ApiResponse.success(historyList));
+		}catch(Exception e) {
+			throw new RuntimeException(e);
+		}
     }
 
     @Override

--- a/src/main/resources/mapper/history.xml
+++ b/src/main/resources/mapper/history.xml
@@ -3,10 +3,9 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.uplus.matdori.category.model.dao.HistoryDAO">
-
-    <!-- 회원별 방문한 식당 히스토리 조회 -->
-    <select id="getHistoryByUserId" parameterType="java.lang.String" resultType="com.uplus.matdori.category.model.dto.HistoryDTO">
-        SELECT * FROM 방문한_식당_히스토리 WHERE user_id2 = #{userId}
+	<!-- 회원별 방문한 식당 히스토리 조회 -->
+    <select id="getUserHistory" parameterType="java.lang.String" resultType="com.uplus.matdori.category.model.dto.HistoryDTO">
+    	SELECT * FROM 방문한_식당_히스토리 WHERE user_id2 = #{user_id};
     </select>
 
     <!-- 방문한 식당 기록 추가 -->


### PR DESCRIPTION
## 📝변경 사항

- 특정 회원의 히스토리 리스트를 불러오기 위해 getUserHistory 메서드 구현
- HistoryServiceImp에서 존재하지 않는 회원 조회 케이스, 존재하는 회원의 히스토리 내역이 없는 케이스를 구분하여 구현

## 🤔리뷰 요구사항 (선택)

- 특정 회원의 히스토리 리스트 조회 시, 존재하는 회원의 히스트리 내역이 없는 경우 빈 ArrayList를 넘겨주었는데, 괜찮은 방법일까요?

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/a1b22f36-5772-497a-b9d1-ebf1751604a0)
- 특정 회원의 히스토리 리스트 조회
---
![image](https://github.com/user-attachments/assets/f22ccd38-4684-4de9-ba99-80211fc8aa81)
- 존재하는 회원이지만 해당 회원의 히스토리 내역이 없을 경우
---
![image](https://github.com/user-attachments/assets/e892edd0-ec05-4133-9373-6aeed6b49783)
- 존재하지 않는 회원의 히스토리 내역을 조회할 경우
---
![image](https://github.com/user-attachments/assets/ba0826d7-fc43-42f8-aeee-8393cf856115)
- 500에러
