### PR TITLE
fix: 평점 입력 시 회원정보 테이블에 포인트 +5씩 적립 되도록 수정

### DIFF
--- a/src/main/java/com/uplus/matdori/category/model/dao/UserDAO.java
+++ b/src/main/java/com/uplus/matdori/category/model/dao/UserDAO.java
@@ -32,4 +32,7 @@ public interface UserDAO {
 
     //특정 카테고리 방문 횟수 증가
     void incrementCategoryVisitCount(@Param("user_id") String userId, @Param("categoryId") int categoryId);
+
+    //특정 회원의 포인트 +5 증가
+    void increaseUserPoint(@Param("user_id") String user_id);
 }

--- a/src/main/java/com/uplus/matdori/category/model/service/HistoryServiceImp.java
+++ b/src/main/java/com/uplus/matdori/category/model/service/HistoryServiceImp.java
@@ -1,8 +1,10 @@
 package com.uplus.matdori.category.model.service;
 
 import com.uplus.matdori.category.model.dao.HistoryDAO;
+import com.uplus.matdori.category.model.dao.UserDAO;
 import com.uplus.matdori.category.model.dto.ApiResponse;
 import com.uplus.matdori.category.model.dto.HistoryDTO;
+import com.uplus.matdori.category.model.dto.UserDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,9 +21,11 @@ import static java.rmi.server.LogStream.log;
 @Service
 public class HistoryServiceImp implements HistoryService {
     private final HistoryDAO historyDAO;
+    private final UserDAO userDAO;
 
-    public HistoryServiceImp(HistoryDAO historyDAO) {
+    public HistoryServiceImp(HistoryDAO historyDAO, UserDAO userDAO) {
         this.historyDAO = historyDAO;
+        this.userDAO = userDAO;
     }
 
     @Override
@@ -50,6 +54,17 @@ public class HistoryServiceImp implements HistoryService {
         // 기존 데이터의 rate를 업데이트
         history.setRate(rate);
         historyDAO.updateRating(history); // DB에 반영
+
+        // user_id가 존재하는지도 확인
+        UserDTO user = userDAO.getUserById(history.getUser_id2());
+
+        // history에 있는 user_id2 값이 유효하지 않아서, user를 제대로 못 불러온 경우
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error("유효하지 않은 history_id 값이에요!"));
+        }
+
+        // 기존 user에서 point를 올려주고, 이를 DAO로 적용시킨다
+        userDAO.increaseUserPoint(history.getUser_id2());
 
         //success일 경우에는 Map.of() 넘겨서.. content는 빈 객체를 넘김
         return ResponseEntity.ok(ApiResponse.success(Map.of()));

--- a/src/main/resources/mapper/user.xml
+++ b/src/main/resources/mapper/user.xml
@@ -44,6 +44,13 @@
         WHERE user_id = #{user_id}
     </update>
 
+    <!-- 특정 회원의 point를 +5 증가 -->
+    <update id="increaseUserPoint" parameterType="String">
+        UPDATE 회원정보
+        SET point = point + 5
+        WHERE user_id = #{user_id}
+    </update>
+
     <!-- 특정 카테고리 방문 횟수 증가 / SQL 인젝션 위험을 방지하기 위해 아래와 같이 안전하게 구성해야 함 -->
     <update id="incrementCategoryVisitCount">
         UPDATE 회원정보


### PR DESCRIPTION
## 📝변경 사항
- "방문한_식당_히스토리"에 평점(rate) 입력 시, "회원정보" 테이블에서 해당 회원의 포인트(point) +5 적립

## 🤔리뷰 요구사항
- "방문한_식당_히스토리" 테이블에서 접근한 특정 행에 있는 user_id 값을 "회원정보" 테이블에서 찾을 수 없을 경우는 예외처리를 발생시킵니다.

## 스크린샷
<img width="1747" alt="스크린샷 2025-03-21 10 16 21" src="https://github.com/user-attachments/assets/84354dee-2937-48ad-9892-3edee2bf5c77" />
"희선이"라는 user_id 값을 "회원정보" 테이블에서 찾아, 해당 회원의 point를 증가 시켰음을 확인할 수 있습니다.